### PR TITLE
Fixed hardcoded values in motor.ino and fixed LCD features disabling

### DIFF
--- a/firmware_rumba/configure.h
+++ b/firmware_rumba/configure.h
@@ -12,8 +12,8 @@
 // CONSTANTS
 //------------------------------------------------------------------------------
 //#define VERBOSE           (1)  // add to get a lot more serial output.
-#define HAS_SD  // comment this out if there is no SD card
-#define HAS_LCD  // comment this out if there is no SMART LCD controller
+//#define HAS_SD  // comment this out if there is no SD card
+//#define HAS_LCD  // comment this out if there is no SMART LCD controller
 //#define USE_LIMIT_SWITCH  (1)  // Comment out this line to disable findHome and limit switches
 
 // machine style
@@ -81,13 +81,11 @@
 #define encrot2            3
 #define encrot3            1
 
-#define NUM_SERVOS         (1)
-#define SERVO0_PIN         (5)
-#define SERVO1_PIN         (4)
 
 
-#define MOTHERBOARD 1 // RUMBA
+//#define MOTHERBOARD 1 // RUMBA
 //#define MOTHERBOARD 2 // RAMPS
+#define MOTHERBOARD 3 // SANGUINOLOLU
 
 #if MOTHERBOARD == 1
 #define MOTOR_0_DIR_PIN           (16)
@@ -121,9 +119,27 @@
 #define MOTOR_5_ENABLE_PIN        (39)
 #define MOTOR_5_LIMIT_SWITCH_PIN  (32)
 
+#define NUM_SERVOS         (1)
+#define SERVO0_PIN         (5)
+#define SERVO1_PIN         (4)
+
 #endif
 
 #if MOTHERBOARD == 2
+#endif
+
+#if MOTHERBOARD == 3
+#define MOTOR_0_DIR_PIN           (21)
+#define MOTOR_0_STEP_PIN          (15)
+#define MOTOR_0_ENABLE_PIN        (14)
+#define MOTOR_0_LIMIT_SWITCH_PIN  (18)
+
+#define MOTOR_1_DIR_PIN           (23)
+#define MOTOR_1_STEP_PIN          (22)
+#define MOTOR_1_ENABLE_PIN        (14)
+#define MOTOR_1_LIMIT_SWITCH_PIN  (19)
+#define NUM_SERVOS         (0)
+#define SERVO0_PIN         (A0)
 #endif
 
 

--- a/firmware_rumba/configure.h
+++ b/firmware_rumba/configure.h
@@ -83,9 +83,9 @@
 
 
 
-//#define MOTHERBOARD 1 // RUMBA
+#define MOTHERBOARD 1 // RUMBA
 //#define MOTHERBOARD 2 // RAMPS
-#define MOTHERBOARD 3 // SANGUINOLOLU
+//#define MOTHERBOARD 3 // SANGUINOLOLU
 
 #if MOTHERBOARD == 1
 #define MOTOR_0_DIR_PIN           (16)

--- a/firmware_rumba/configure.h
+++ b/firmware_rumba/configure.h
@@ -12,8 +12,8 @@
 // CONSTANTS
 //------------------------------------------------------------------------------
 //#define VERBOSE           (1)  // add to get a lot more serial output.
-//#define HAS_SD  // comment this out if there is no SD card
-//#define HAS_LCD  // comment this out if there is no SMART LCD controller
+#define HAS_SD  // comment this out if there is no SD card
+#define HAS_LCD  // comment this out if there is no SMART LCD controller
 //#define USE_LIMIT_SWITCH  (1)  // Comment out this line to disable findHome and limit switches
 
 // machine style
@@ -83,9 +83,9 @@
 
 
 
-//#define MOTHERBOARD 1 // RUMBA
+#define MOTHERBOARD 1 // RUMBA
 //#define MOTHERBOARD 2 // RAMPS
-#define MOTHERBOARD 3 // SANGUINOLOLU
+//#define MOTHERBOARD 3 // SANGUINOLOLU
 
 #if MOTHERBOARD == 1
 #define MOTOR_0_DIR_PIN           (16)
@@ -138,6 +138,7 @@
 #define MOTOR_1_STEP_PIN          (22)
 #define MOTOR_1_ENABLE_PIN        (14)
 #define MOTOR_1_LIMIT_SWITCH_PIN  (19)
+
 #define NUM_SERVOS         (0)
 #define SERVO0_PIN         (A0)
 #endif

--- a/firmware_rumba/configure.h
+++ b/firmware_rumba/configure.h
@@ -140,7 +140,7 @@
 #define MOTOR_1_LIMIT_SWITCH_PIN  (19)
 
 #define NUM_SERVOS         (0)
-#define SERVO0_PIN         (A0)
+#define SERVO0_PIN         (12)
 #endif
 
 

--- a/firmware_rumba/firmware_rumba.ino
+++ b/firmware_rumba/firmware_rumba.ino
@@ -767,7 +767,7 @@ void Serial_listen() {
 void loop() {
   Serial_listen();
   SD_check();
-  LCD_update();
+//  LCD_update();
 
   // The PC will wait forever for the ready signal.
   // if Arduino hasn't received a new instruction in a while, send ready() again

--- a/firmware_rumba/firmware_rumba.ino
+++ b/firmware_rumba/firmware_rumba.ino
@@ -767,7 +767,9 @@ void Serial_listen() {
 void loop() {
   Serial_listen();
   SD_check();
-//  LCD_update();
+#ifdef HAS_LCD
+  LCD_update();
+#endif
 
   // The PC will wait forever for the ready signal.
   // if Arduino hasn't received a new instruction in a while, send ready() again

--- a/firmware_rumba/motor.ino
+++ b/firmware_rumba/motor.ino
@@ -541,7 +541,7 @@ void motor_line(long n0,long n1,long n2,float new_feed_rate) {
   }
 
   // use LCD to adjust speed while drawing
-  new_feed_rate *= (float)speed_adjust * 0.01f;
+  // new_feed_rate *= (float)speed_adjust * 0.01f;
 
   int prev_segment = get_prev_segment(last_segment);
   Segment &new_seg = line_segments[last_segment];

--- a/firmware_rumba/motor.ino
+++ b/firmware_rumba/motor.ino
@@ -83,17 +83,17 @@ float max_speed_allowed(float acceleration, float target_velocity, float distanc
  * set up the pins for each motor
  */
 void motor_setup() {
-  motors[0].step_pin=17;
-  motors[0].dir_pin=16;
-  motors[0].enable_pin=48;
-  motors[0].limit_switch_pin=37;
+  motors[0].step_pin=MOTOR_0_STEP_PIN;
+  motors[0].dir_pin=MOTOR_0_DIR_PIN;
+  motors[0].enable_pin=MOTOR_0_ENABLE_PIN;
+  motors[0].limit_switch_pin=MOTOR_0_LIMIT_SWITCH_PIN;
   motors[0].reel_in  = HIGH;
   motors[0].reel_out = LOW;
 
-  motors[1].step_pin=54;
-  motors[1].dir_pin=47;
-  motors[1].enable_pin=55;
-  motors[1].limit_switch_pin=36;
+  motors[1].step_pin=MOTOR_1_STEP_PIN;
+  motors[1].dir_pin=MOTOR_1_DIR_PIN;
+  motors[1].enable_pin=MOTOR_1_ENABLE_PIN;
+  motors[1].limit_switch_pin=MOTOR_1_LIMIT_SWITCH_PIN;
   motors[1].reel_in  = HIGH;
   motors[1].reel_out = LOW;
 

--- a/firmware_rumba/motor.ino
+++ b/firmware_rumba/motor.ino
@@ -541,7 +541,9 @@ void motor_line(long n0,long n1,long n2,float new_feed_rate) {
   }
 
   // use LCD to adjust speed while drawing
-  // new_feed_rate *= (float)speed_adjust * 0.01f;
+#ifdef HAS_LCD
+  new_feed_rate *= (float)speed_adjust * 0.01f;
+#endif
 
   int prev_segment = get_prev_segment(last_segment);
   Segment &new_seg = line_segments[last_segment];


### PR DESCRIPTION
The firmware should now be usable on boards other than a rumba and other boards can now be added.
- Added support for Sanguinololu board
- Replaced hardcoded pins values from motor.ino with the values from configure.h
- Disabled some lcd features when HAS_LCD is not set so that it would compile
