### PR TITLE
Fix parsing an old command without wanting to.

### DIFF
--- a/Makelangelo-firmware.ino
+++ b/Makelangelo-firmware.ino
@@ -857,7 +857,8 @@ void parseBeep() {
    process commands in the serial receive buffer
 */
 void processCommand() {
-  if (serialBuffer[0] == ';') return;  // blank lines
+
+  if ((serialBuffer[0] == '\0') || (serialBuffer[0] == ';')) return;  // blank lines
   if (!checkLineNumberAndCRCisOK()) return; // message garbled
 
   if (!strncmp(serialBuffer, "UID", 3)) {

--- a/motor.cpp
+++ b/motor.cpp
@@ -196,6 +196,7 @@ void motor_setup() {
   tmc_setup(driver_0);
   tmc_setup(driver_1);
   vsense = driver_0.vsense();
+#endif
 
   motors[0].step_pin        = MOTOR_0_STEP_PIN;
   motors[0].dir_pin         = MOTOR_0_DIR_PIN;


### PR DESCRIPTION
Dan,

   Here is I think the correct fix to the problem I was having with the motor step_count. At least this
change stops it from happening

Also fixed a missing #endif

Michael