### PR TITLE
Use interrupts to get rotary encoder info

### DIFF
--- a/lcd.cpp
+++ b/lcd.cpp
@@ -776,10 +776,10 @@ void LCD_update() {
     // if we are polling in the interrupt, then seeif there was any change 
     if (int_lcd_turn)
     {
-//        noInterrupts();
+        noInterrupts();
         lcd_turn = int_lcd_turn;
         int_lcd_turn = 0;
-//        interrupts();
+        interrupts();
     }
 #endif  
 

--- a/lcd.cpp
+++ b/lcd.cpp
@@ -29,8 +29,8 @@
 // STRUCTURES
 //------------------------------------------------------------------------------
 typedef struct {
-  // number of clicks of the dial
-  uint8_t menu_position_sum;
+  // number of clicks of the dial, This can be + or -
+  int8_t menu_position_sum;
   // number of clicks / LCD_TURN_PER_MENU
   uint8_t menu_position;
   // menu being used
@@ -52,6 +52,9 @@ uint32_t lcd_draw_delay  = 0;
 
 int lcd_rot_old  = 0;
 int lcd_turn     = 0;
+#if defined(LCD_INT_POLLING)
+int int_lcd_turn = 0;
+#endif
 int lcd_posx = 0, lcd_posy = 0;
 char lcd_click_old = HIGH;
 char lcd_click_now = 0;
@@ -313,6 +316,13 @@ void *update_val;
 
 
 void LCD_read() {
+  int *lcd_turn_ptr = &lcd_turn;
+  
+#if defined(LCD_INT_POLLING)
+  buttons = ((digitalRead(BTN_EN1) == LOW) << BLEN_A)
+            | ((digitalRead(BTN_EN2) == LOW) << BLEN_B);
+  lcd_turn_ptr = &int_lcd_turn;
+#else
   long now = millis();
   
   if(ELAPSED(now,next_lcd_read)) {
@@ -321,23 +331,26 @@ void LCD_read() {
             | ((digitalRead(BTN_EN2) == LOW) << BLEN_B);
     next_lcd_read=now+30;
   }
-  
+#endif
+
   // potentiometer uses grey code.  Pattern is 0 3 1 2
   if (lcd_rot_old != buttons) {
     switch (buttons) {
-      case ENCROT0:  switch( lcd_rot_old ) { case ENCROT3: lcd_turn++; break; case ENCROT1: lcd_turn--; break; } break;
-      case ENCROT1:  switch( lcd_rot_old ) { case ENCROT0: lcd_turn++; break; case ENCROT2: lcd_turn--; break; } break;
-      case ENCROT2:  switch( lcd_rot_old ) { case ENCROT1: lcd_turn++; break; case ENCROT3: lcd_turn--; break; } break;
-      case ENCROT3:  switch( lcd_rot_old ) { case ENCROT2: lcd_turn++; break; case ENCROT0: lcd_turn--; break; } break;
-    }
+      case ENCROT0:  switch( lcd_rot_old ) { case ENCROT3: (*lcd_turn_ptr)++; break; case ENCROT1: (*lcd_turn_ptr)--; break; } break;
+      case ENCROT1:  switch( lcd_rot_old ) { case ENCROT0: (*lcd_turn_ptr)++; break; case ENCROT2: (*lcd_turn_ptr)--; break; } break;
+      case ENCROT2:  switch( lcd_rot_old ) { case ENCROT1: (*lcd_turn_ptr)++; break; case ENCROT3: (*lcd_turn_ptr)--; break; } break;
+      case ENCROT3:  switch( lcd_rot_old ) { case ENCROT2: (*lcd_turn_ptr)++; break; case ENCROT0: (*lcd_turn_ptr)--; break; } break;
+    } 
     // for debugging potentiometer
     {
-      //if(lcd_turn !=0) Serial.print(lcd_turn>0?'+':'-');
-      //else Serial.print(' ');
+#if 0
+      if(*lcd_turn_ptr !=0) Serial.print(*lcd_turn_ptr>0?'+':'-');
+      else Serial.print(' ');
       //Serial.print(millis());     Serial.print('\t');
-      //Serial.print(lcd_rot_old);  Serial.print('\t');
-      //Serial.print(buttons);      Serial.print('\t');
-      //Serial.print(lcd_turn);     Serial.print('\n');
+      Serial.print(lcd_rot_old);  Serial.print('\t');
+      Serial.print(buttons);      Serial.print('\t');
+      Serial.print(*lcd_turn_ptr);     Serial.print('\n');
+#endif
     }
     
     lcd_rot_old = buttons;
@@ -750,16 +763,27 @@ void LCD_print_float(float v,int padding,int precision) {
 #endif  // HAS_LCD
 
 
-
-
 void LCD_update() {
 #ifdef HAS_LCD
+# if !defined(LCD_INT_POLLING)
   LCD_read();
-  
+# endif
+
   if (millis() >= lcd_draw_delay ) {
     lcd_draw_delay = millis() + LCD_DRAW_DELAY;
 
-    //Serial.print(lcd_turn,DEC);
+#if defined(LCD_INT_POLLING)
+    // if we are polling in the interrupt, then seeif there was any change 
+    if (int_lcd_turn)
+    {
+//        noInterrupts();
+        lcd_turn = int_lcd_turn;
+        int_lcd_turn = 0;
+//        interrupts();
+    }
+#endif  
+
+    //Serial.println(lcd_turn,DEC);
     //Serial.print('\t');  Serial.print(menuStack[menuStackDepth].menu_position,DEC);
     //Serial.print('\t');  Serial.print(menuStack[menuStackDepth].menu_position_sum,DEC);
     //Serial.print('\t');  Serial.print(screen_position,DEC);
@@ -800,12 +824,11 @@ void LCD_update() {
     do {
     #endif
       (*current_menu)();
+      lcd_turn = 0;  // reset.  must come after (*current_menu)() because it might be used there.  (damn globals...)
     #ifdef LCD_IS_128X64
     } while(u8g.nextPage());
     #endif
     LCD_refresh_display();
-
-    lcd_turn = 0;  // reset.  must come after (*current_menu)() because it might be used there.  (damn globals...)
   }
 #endif  // HAS_LCD
 }

--- a/lcd.h
+++ b/lcd.h
@@ -30,6 +30,9 @@
 
 #include "dogm_font_data_6x9.h"
 
+// turn this on. Using the motor interrupt we will gather the encoder info
+#define LCD_INT_POLLING 
+#define LCD_TURN_PER_MENU  (4)  // with the latest 128x64 each click is 4 counts, this seems to work well.
 #endif
 
 //----------------------------------------------------
@@ -66,7 +69,10 @@
 
 #define LCD_MESSAGE_LENGTH (LCD_HEIGHT * LCD_WIDTH + 1)  // we have two lines of 20 characters avialable in 7.16
 #define LCD_DRAW_DELAY     (100)
+
+#ifndef LCD_TURN_PER_MENU
 #define LCD_TURN_PER_MENU  (3)  // was 5
+#endif
 
 extern char lcd_message[LCD_MESSAGE_LENGTH+1];
 extern char lcd_message_m117[LCD_MESSAGE_LENGTH/2+1];

--- a/motor.cpp
+++ b/motor.cpp
@@ -761,7 +761,16 @@ static FORCE_INLINE uint16_t MultiU24X32toH16(uint32_t longIn1, uint32_t longIn2
 /**
  *  Process all line segments in the ring buffer.  Uses bresenham's line algorithm to move all motors.
  */
+#if defined(HAS_LCD) && defined(LCD_INT_POLLING)
+extern void LCD_read(void);
+#endif
+
 inline void isr_internal() {
+#if defined(HAS_LCD) && defined(LCD_INT_POLLING)
+  // call the rotary encoder polling
+  LCD_read();
+#endif
+
   // segment buffer empty? do nothing
   if ( working_seg == NULL ) {
     working_seg = get_current_segment();

--- a/motor.cpp
+++ b/motor.cpp
@@ -767,8 +767,13 @@ extern void LCD_read(void);
 
 inline void isr_internal() {
 #if defined(HAS_LCD) && defined(LCD_INT_POLLING)
-  // call the rotary encoder polling
-  LCD_read();
+  static uint8_t _intTimes = 0;
+
+  if ((_intTimes++ % 10) == 0)
+  {
+    // call the rotary encoder polling
+    LCD_read();
+  }
 #endif
 
   // segment buffer empty? do nothing


### PR DESCRIPTION
Dan,

Please look at these changes. I have NOT yet tested on the 20x4 LCD, but this works great on the
128x64 LCD. I believe that this change will work for both. But I wanted to err on the side of caution so I put #if around the code, so the feature can be enabled or disabled and only turned it on for the 128x64. I plan on testing this with the 20x4 LCD by this weekend.

I wanted your opinion on both the basic idea of using the motor interrupt to read the encoder info and on the implementation.

I did not test with the 20x4 LCD but I did compile and run it on my system and it seems to respond to serial commands just fine.

Michael

P.S.
   I had to make changes to the pins in the board_ramps.h to get my board to actually work. Those changes are not part of this pull. I can add it if you want.