### PR TITLE
Implement interrupts for 12864 LCD encoder with RAMPS 1.4 configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ local_config.h
 
 # folder created by platformio
 .pio
+/.metadata/

--- a/board_ramps.h
+++ b/board_ramps.h
@@ -58,22 +58,35 @@
 // 128x64 full graphics controller
 #define BEEPER             37
 
+#ifdef USING_12864_WITH_ENCODER_INTERRUPTS
+// these alternate pins might help - see https://www.marginallyclever.com/forums/topic/using-reprap-kit-from-amazon-ramps-1-6-lcd-display/#post-22131
+// these settings worked with my Mega 2560/Ramps 1.4 and are needed for using encoder interrupts since the interrupts use D18 and D19 
+#define LCD_PINS_RS        16
+#define LCD_PINS_ENABLE    17
+#define LCD_PINS_D4        23
+#else
+
 #define LCD_PINS_RS        19
 #define LCD_PINS_ENABLE    42
 #define LCD_PINS_D4        18
-// these alternate pins might help - see https://www.marginallyclever.com/forums/topic/using-reprap-kit-from-amazon-ramps-1-6-lcd-display/#post-22131
-//#define LCD_PINS_RS        16
-//#define LCD_PINS_ENABLE    17
-//#define LCD_PINS_D4        23
+#endif
 
 #define LCD_PINS_D5        25
 #define LCD_PINS_D6        27
 #define LCD_PINS_D7        29
 
 // Encoder rotation values
-#define BTN_EN1            31
-#define BTN_EN2            33
+#ifdef USING_12864_WITH_ENCODER_INTERRUPTS
+#define BTN_EN1            18    // solder a jumper from D33 on the display connector to D18 on the RAMPS 1.4 board
+#define BTN_EN1_OLD        33    // this pin is still connected and has to be set to an input
+#define BTN_EN2            19    // solder a jumper from D31 on the display connector to D19 on the RAMPS 1.4 board
+#define BTN_EN2_OLD        31    // this pin is still connected and has to be set to an input
+#define BTN_ENC            35    // did not modify code / jumper board to add an interrupt for the button function
+#else
+#define BTN_EN1            33
+#define BTN_EN2            31
 #define BTN_ENC            35
+#endif
 
 // SD card settings
 #define SDPOWER            -1

--- a/configure.h
+++ b/configure.h
@@ -40,7 +40,9 @@
 #define LCD_IS_SMART   2  // reprapdiscount Smart LCD Controller (including XXL model)
 
 // default value
-#define LCD_TYPE LCD_IS_SMART
+#define LCD_TYPE LCD_IS_128X64
+
+#define USING_12864_WITH_ENCODER_INTERRUPTS
 
 //------------------------------------------------------------------------------
 // Microcontrollers supported
@@ -56,7 +58,7 @@
 #define BOARD_ESP32        8  // ESP32 + Marginally Clever Polargraph PCB.
 
 // default value
-#define MOTHERBOARD BOARD_RUMBA
+#define MOTHERBOARD BOARD_RAMPS
 
 //------------------------------------------------------------------------------
 // YOUR CHANGES GO HERE

--- a/lcd.h
+++ b/lcd.h
@@ -65,7 +65,7 @@
 
 #define LCD_MESSAGE_LENGTH (LCD_HEIGHT * LCD_WIDTH + 1)  // we have two lines of 20 characters avialable in 7.16
 #define LCD_DRAW_DELAY     (100)
-#define LCD_TURN_PER_MENU  (3)  // was 5
+#define LCD_TURN_PER_MENU  (1)  // was 5
 #define M117_MAX_LEN       (LCD_MESSAGE_LENGTH/2)
 
 extern uint8_t speed_adjust;  // used by planner


### PR DESCRIPTION
A configuration item named USING_12864_WITH_ENCODER_INTERRUPTS
was added to the board_ramps.h include file to enable interrupt usage.

These changes require adding a jumper from D33 to D18, and one from
D31 to D19.  These can be done from the display connector to pins on
the RAMPS 1.4 board.  I cut a female jumper cable in half, soldered
the wire to the display adapter, and used the female end to attach to
the correct pin on the RAMPS 1.4 board.

D33 and D31 will still be set to inputs and receive the signal, but
they are not used.  Interrupts are enabled for D18 and D19, their
pull-ups are enabled, and the signal is read from the new pins.

Code was written to process the interrupts and handle menus.  Turning
the knob quicker will increment float and long values quicker.

The button press was not moved to an interrupt.  It still must be held
sufficiently long for the polling code to recognize the button press.