### PR TITLE
Report 8e734685327455a484803ad0a4279bb79b84800e on sixi3

### DIFF
--- a/src/robots/sixi3.cpp
+++ b/src/robots/sixi3.cpp
@@ -88,10 +88,10 @@ void factory_reset() {
     motor_spu[i]=STEPS_PER_UNIT;
   }
   motor_spu[NUM_MOTORS]=1;
-  
+
   for (ALL_MUSCLES(i)) {
     max_jerk[i] = MAX_JERK_DEFAULT;
-    max_step_rate_s[i] = MAX_STEP_RATE_DEFAULT;
+    max_step_rate[i] = MAX_STEP_RATE_DEFAULT * motor_spu[i];
   }
 
   // if you accidentally upload m3 firmware to an m5 then upload it ONCE with this line uncommented.


### PR DESCRIPTION
Hi, 

this PR fix the Continuous Integration compilation due to changes in 8e734685327455a484803ad0a4279bb79b84800e. I think the file `src/robots/sixi3.cpp` has been forgotten.

It is not enough to fix the CI, a lot of error are still present, I think they are due to this commit : https://github.com/MarginallyClever/Makelangelo-firmware/commit/d63d367b0f0f124cdc148c0da1f5936bb6d75e7b
eg : 
```
src/robots/sixi3.cpp:54:36: error: no matching function for call to 'println(const __FlashStringHelper*)'
   MYSERIAL1.println(F("Finding..."));
                                    ^
In file included from src/serial_hook.h:24:0,
                 from src/boards/MarlinSerial.h:37,
                 from src/configure.h:125,
                 from src/robots/sixi3.cpp:7:
```

@i-make-robots what do you think ?