### PR TITLE
Add matrix compilation to build all available environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run
+      run: pio run --environment ${MATRIX_ENV}
       env:
-        PLATFORMIO_DEFAULT_ENVS: ${{ matrix.env }}
+        MATRIX_ENV: ${{ matrix.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [ramps-polargraph, rumba-polargraph, BIGTREE_SKR_PRO-Sixi3, sixi2, BIGTREE_SKR_PRO-Stewart, rumba-sixi3]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,4 +31,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run 
+      run: pio run
+      env:
+        PLATFORMIO_DEFAULT_ENVS: ${{ matrix.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env: [ramps-polargraph, rumba-polargraph, BIGTREE_SKR_PRO-Sixi3, sixi2, BIGTREE_SKR_PRO-Stewart, rumba-sixi3]
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ local_config.h
 .clang_complete
 .gcc-flags.json
 .pio
+__pycache__
 
 # Editor stuff
 


### PR DESCRIPTION
Hi, 

here is an enhancement of the github action which compiles all available environnements: `ramps-polargraph, rumba-polargraph, BIGTREE_SKR_PRO-Sixi3, sixi2, BIGTREE_SKR_PRO-Stewart, rumba-sixi3`

Here is a screenshot of the github action:
![image](https://user-images.githubusercontent.com/23615562/129421519-0bec66e0-01a9-455c-91cc-12a2677c5f09.png)
