### PR TITLE
Dynamically add env to the matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,7 @@ jobs:
     # This step is explained more in a following section
     - id: set-matrix
       run: |
-        matrix=$(
-          echo '['
-          sed -n 's/\[env:\(.*\)\]/"\1"/p' platformio.ini | tr '\n' ',' | sed 's/,$/\n/'
-          echo ']'
-        )
+        matrix="[$(sed -n 's/\[env:\(.*\)\]/"\1"/p' platformio.ini | tr '\n' ',' | sed 's/,$/\n/')]"
         echo $matrix
         echo $matrix | jq .
         echo "::set-output name=matrix::$matrix"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,16 @@ jobs:
         echo $matrix | jq .
         echo "::set-output name=matrix::$matrix"
 
+  check-matrix:
+    runs-on: ubuntu-latest
+    needs: matrix_prep
+    steps:
+      - name: Check matrix definition
+        run: |
+          matrix='${{ needs.matrix.outputs.matrix }}'
+          echo $matrix
+          echo $matrix | jq .
+
   build:
     runs-on: ubuntu-latest
     needs: matrix_prep
@@ -36,5 +46,5 @@ jobs:
 
     steps:
     - run: echo "env to build ${MATRIX_ENV}"
-    env:
-      MATRIX_ENV: ${{ matrix.env }}
+      env:
+        MATRIX_ENV: ${{ matrix.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check matrix definition
         run: |
-          matrix='${{ needs.matrix.outputs.matrix }}'
+          matrix='${{ needs.matrix_prep.outputs.matrix }}'
           echo $matrix
           echo $matrix | jq .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
     # This step is explained more in a following section
     - id: set-matrix
       run: |
-        matrix=$((
+        matrix=$(
           echo '['
           sed -n 's/\[env:\(.*\)\]/"\1"/p' platformio.ini | tr '\n' ',' | sed 's/,$/\n/'
-          echo "]"
-        ))
+          echo ']'
+        )
         echo $matrix
         echo $matrix | jq .
         echo "::set-output name=matrix::$matrix"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,35 +3,38 @@ name: PlatformIO CI
 on: [push]
 
 jobs:
-  build:
 
+  matrix_prep:
+    # Using a separate job and agent so as to be able to use tools like 'sed' and 'jq'
     runs-on: ubuntu-latest
+    # Defining outputs of a job allows for easier consumption and use
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    # Checking out code as the set-matrix step utilizes a file named matrix_includes.json
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    # This step is explained more in a following section
+    - id: set-matrix
+      run: |
+        matrix=$((
+          echo '{ "build" : ['
+          sed -n 's/\[env:\(.*\)\]/"\1"/p' platformio.ini | tr '\n' ',' | sed 's/,$/\n/'
+          echo " ]}"
+        ) | jq -c .)
+        echo $matrix
+        echo $matrix | jq .
+        echo "::set-output name=matrix::$matrix"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: matrix_prep
     strategy:
       fail-fast: false
       matrix:
-        env: [ramps-polargraph, rumba-polargraph, BIGTREE_SKR_PRO-Sixi3, sixi2, BIGTREE_SKR_PRO-Stewart, rumba-sixi3, cnc3-polargraph]
+        env: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Cache PlatformIO
-      uses: actions/cache@v2
-      with:
-        path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
-    - name: Set up Python
-      uses: actions/setup-python@v2
-    - name: Install PlatformIO
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade platformio
-    - name: Run PlatformIO
-      run: pio run --environment ${MATRIX_ENV}
-      env:
-        MATRIX_ENV: ${{ matrix.env }}
+    - run: echo "env to build ${MATRIX_ENV}"
+    env:
+      MATRIX_ENV: ${{ matrix.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,24 +31,24 @@ jobs:
         env: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Cache PlatformIO
-        uses: actions/cache@v2
-        with:
-          path: ~/.platformio
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
-      - name: Set up Python
-        uses: actions/setup-python@v2
-      - name: Install PlatformIO
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade platformio
-      - name: Run PlatformIO
-        run: pio run --environment ${MATRIX_ENV}
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+    - name: Run PlatformIO
+      run: pio run --environment ${MATRIX_ENV}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,5 @@ jobs:
         pip install --upgrade platformio
     - name: Run PlatformIO
       run: pio run --environment ${MATRIX_ENV}
+      env:
+        MATRIX_ENV: ${{ matrix.env }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,23 +18,13 @@ jobs:
     - id: set-matrix
       run: |
         matrix=$((
-          echo '{ "build" : ['
+          echo '['
           sed -n 's/\[env:\(.*\)\]/"\1"/p' platformio.ini | tr '\n' ',' | sed 's/,$/\n/'
-          echo " ]}"
-        ) | jq -c .)
+          echo "]"
+        ))
         echo $matrix
         echo $matrix | jq .
         echo "::set-output name=matrix::$matrix"
-
-  check-matrix:
-    runs-on: ubuntu-latest
-    needs: matrix_prep
-    steps:
-      - name: Check matrix definition
-        run: |
-          matrix='${{ needs.matrix_prep.outputs.matrix }}'
-          echo $matrix
-          echo $matrix | jq .
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,24 @@ jobs:
         env: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
 
     steps:
-    - run: echo "env to build ${MATRIX_ENV}"
-      env:
-        MATRIX_ENV: ${{ matrix.env }}
+      - uses: actions/checkout@v2
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache PlatformIO
+        uses: actions/cache@v2
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+      - name: Run PlatformIO
+        run: pio run --environment ${MATRIX_ENV}


### PR DESCRIPTION
Hi,

instead of having to manually add new environment as I did in https://github.com/MarginallyClever/Makelangelo-firmware/commit/01ce2bd486a5c31f5748cb6cb3c10e64ca801f7e, here is an enhancement that takes all `[env:*]` from the `platformio.ini` and add them to the matrix. Thus, every time a new environment is add or removed from this file, the CI will be updated.

I followed this guide : https://www.cynkra.com/blog/2020-12-23-dynamic-gha/